### PR TITLE
Refactor LLM validation to use structured expected vs actual comparison

### DIFF
--- a/src/asserts/assertProcessBuilderOutput.ts
+++ b/src/asserts/assertProcessBuilderOutput.ts
@@ -45,9 +45,8 @@ export async function assertProcessBuilderOutput({
   const llmResponse = await request.newContext().then(ctx =>
     ctx.post(llmCheckUrl, {
       data: {
-        instructions: semanticExpectation,
-        prompt: prompt,
-        llm_response: outputStages.join('\n'),
+        expected: semanticExpectation,
+        actual: outputStages.join('\n'),
       },
       headers: { 'Content-Type': 'application/json' },
     })
@@ -55,12 +54,11 @@ export async function assertProcessBuilderOutput({
 
   expect(llmResponse.status()).toBe(200);
 
+  expect(llmResponse.status()).toBe(200);
   const llmJson = await llmResponse.json();
-  console.log(`[LLM Cloud Judgment]`, llmJson);
-  expect(llmJson.result).toBe(true);
-  if (llmJson.score) {
-    expect(llmJson.score).toBeGreaterThanOrEqual(llmMinScore);
-  }
+  console.log('[LLM Score Response]', llmJson);
+  expect(typeof llmJson.score).toBe('number');
+  expect(llmJson.score).toBeGreaterThanOrEqual(llmMinScore);
 
   if (semanticExpectation) {
     const combinedOutput = outputStages.join(' ');


### PR DESCRIPTION
### Summary

This PR updates the `assertProcessBuilderOutput` utility to use a simplified and more robust LLM validation contract. It now sends only two parameters—`expected` and `actual`—to the external scoring service. The response is a numeric score between 1 and 5, representing semantic similarity between the expected and generated outputs.

### Key Changes

* Replaces the previous POST payload fields (`instructions`, `prompt`, `llm_response`) with:

  ```
  data: {
    expected: semanticExpectation,
    actual: outputStages.join('\n')
  }
  ```
* Removes validation on the `result` boolean field.
* Adds strict checks to ensure `score` is a number and meets the `llmMinScore` threshold.